### PR TITLE
Add --noverify option, fix CONNECT request reading, fix Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Forwarders that have been tested:
     $ ./sni-changer-using-mitm-proxy <root-ca-location> <root-key-location> <key-password>
 ```
 You can add the `--noverify` option in the end to disable server TLS certificate check.
+
 7. Set the forwarder to the right port.
 - In Firefox: `Setting -> General -> Network Settings -> Settings -> Manual Proxy Configuration`. In HTTPS Proxy, type: `localhost` and port `8080`.
 8. **You’re good to go!** Next time, only **step 6 is necessary to run** the project.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Forwarders that have been tested:
 ```shell
     $ make
 ```
-5. Configure te websites where SNI should be changed in `sni.conf`.
+5. Configure the websites where SNI should be changed in `sni.conf`.
 6. Run the application.
 ```shell
     # In case you created your certificate with make cert.

--- a/README.md
+++ b/README.md
@@ -45,16 +45,18 @@ Forwarders that have been tested:
 ```shell
     $ make
 ```
-5. Run the application.
+5. Configure te websites where SNI should be changed in `sni.conf`.
+6. Run the application.
 ```shell
     # In case you created your certificate with make cert.
     $ ./sni-changer-using-mitm-proxy cert/rootCA.pem cert/rootCA.key <key-password>
     # If you have independently generated your own certificate.
     $ ./sni-changer-using-mitm-proxy <root-ca-location> <root-key-location> <key-password>
 ```
-6. Set the forwarder to the right port.
+You can add the `--noverify` option in the end to disable server TLS certificate check.
+7. Set the forwarder to the right port.
 - In Firefox: `Setting -> General -> Network Settings -> Settings -> Manual Proxy Configuration`. In HTTPS Proxy, type: `localhost` and port `8080`.
-7. **You’re good to go!** Next time, only **step 5 is necessary to run** the project.
+8. **You’re good to go!** Next time, only **step 6 is necessary to run** the project.
 
 ## Credits
 This tool was developed by Victor Netto, [Thibault Cholez](https://github.com/cholezth) and [Xavier Marchal](https://github.com/Nayald) of RESIST research group in [LORIA](https://www.loria.fr/fr/), France.

--- a/src/cert/cert.c
+++ b/src/cert/cert.c
@@ -171,7 +171,7 @@ int sign_certificate(EVP_PKEY *ca_key, const X509 *ca_crt, EVP_PKEY **key,
         goto error;
 
     // Set metadata of the certificate.
-    X509_set_version(*crt, 3);
+    X509_set_version(*crt, 2);
     X509_set_issuer_name(*crt, X509_get_subject_name(ca_crt));
     X509_set_subject_name(*crt, X509_REQ_get_subject_name(req));
     X509_gmtime_adj(X509_get_notBefore(*crt), 0);

--- a/src/tls/client/tls-client.c
+++ b/src/tls/client/tls-client.c
@@ -107,7 +107,7 @@ char *get_sni_from_domain(struct sni_change *sni_changes, char *domain) {
  */
 int create_TLS_connection_with_host_with_changed_SNI(
     SSL_CTX *ctx, struct sni_change *sni_changes,
-    struct ssl_connection *ssl_connection) {
+    struct ssl_connection *ssl_connection, bool no_verify) {
 
     fprintf(stdout, "(info) Creating TLS connection:\n");
     fprintf(stdout, "(info) Hostname: %s\n", ssl_connection->hostname);
@@ -126,7 +126,9 @@ int create_TLS_connection_with_host_with_changed_SNI(
 
     // Configure the client to abort the handshake if certificate
     // verification fails.
-    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+    if (!no_verify) {
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+    }
 
     // Use the default trusted certificate store
     if (!SSL_CTX_set_default_verify_paths(ctx)) {

--- a/src/tls/client/tls-client.h
+++ b/src/tls/client/tls-client.h
@@ -10,6 +10,6 @@
 
 int create_TLS_connection_with_host_with_changed_SNI(
     SSL_CTX *ctx, struct sni_change *sni_changes,
-    struct ssl_connection *ssl_connection);
+    struct ssl_connection *ssl_connection, bool no_verify);
 
 #endif // !TLS_CLIENT_H

--- a/src/tls/io/tls-handshake.c
+++ b/src/tls/io/tls-handshake.c
@@ -1,4 +1,5 @@
 #include "tls-handshake.h"
+#include <openssl/err.h>
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -50,6 +51,11 @@ int do_tls_handshake(SSL *ssl, int fd, bool is_server) {
                         "(error) Write-select error in handshake TLS.\n");
                 return -1;
             }
+        } else if (decodedError == SSL_ERROR_SSL) {
+            char msg[4096];
+            ERR_error_string_n(ERR_get_error(), msg, sizeof(msg));
+            fprintf(stderr, "(error) TLS %s error: %s\n", is_server ? "server" : "client", msg);
+            return -1;
         } else {
             fprintf(stderr, "(error) Error creating SSL connection.  err=%x\n",
                     decodedError);

--- a/src/tls/server/tls-server.c
+++ b/src/tls/server/tls-server.c
@@ -182,6 +182,11 @@ int create_TLS_connection_with_user(SSL_CTX *ctx, struct root_ca root_ca,
     }
     connect_message[size] = '\0';
 
+    while (!strstr(connect_message, "\r\n\r\n")) {
+        size += read(connection_fd, connect_message + size, BUFFER_SIZE - size);
+        connect_message[size] = '\0';
+    }
+
     // Set new connection socket to non-blocking mode.
     if (fcntl(connection_fd, F_SETFL, O_NONBLOCK) == -1) {
         perror("Error setting socket to non-blocking mode");

--- a/src/tls/server/tls-server.c
+++ b/src/tls/server/tls-server.c
@@ -175,7 +175,7 @@ int create_TLS_connection_with_user(SSL_CTX *ctx, struct root_ca root_ca,
     char connect_message[BUFFER_SIZE];
 
     // Read the CONNECT from the client.
-    size_t size = read(connection_fd, connect_message, BUFFER_SIZE);
+    ssize_t size = read(connection_fd, connect_message, BUFFER_SIZE);
     if (size <= 0) {
         fprintf(stderr, "(error) Error reading user socket.\n");
         return -1;
@@ -183,7 +183,12 @@ int create_TLS_connection_with_user(SSL_CTX *ctx, struct root_ca root_ca,
     connect_message[size] = '\0';
 
     while (!strstr(connect_message, "\r\n\r\n")) {
-        size += read(connection_fd, connect_message + size, BUFFER_SIZE - size);
+        ssize_t read_result = read(connection_fd, connect_message + size, BUFFER_SIZE - size);
+        if (read_result <= 0) {
+            fprintf(stderr, "(error) Error reading user socket, %zd bytes have been read.\n", size);
+            return -1;
+        }
+        size += read_result;
         connect_message[size] = '\0';
     }
 


### PR DESCRIPTION
* Option to disable certificate verification.
* Reading the CONNECT request fully before trying to establish a TLS connection on that descriptor. Firefox on Android sends CONNECT headers in a separate TCP packet, so first read doesn't consume it fully and TLS handshake fails on that descriptor later.